### PR TITLE
feat: Add SDL canvas renderer option (Fixes #1)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -22,6 +22,8 @@ let fgOnly = false;
 let dither = false;
 let disableGamepad = false;
 let debugInput = false;
+let videoMode = 'terminal';
+let scale = 2;
 
 for (let i = 0; i < args.length; i++) {
   if (args[i] === '--save-dir' && args[i + 1]) {
@@ -38,6 +40,10 @@ for (let i = 0; i < args.length; i++) {
     fgOnly = true;
   } else if (args[i] === '--dither') {
     dither = true;
+  } else if (args[i] === '--video' && args[i + 1]) {
+    videoMode = args[++i];
+  } else if (args[i] === '--scale' && args[i + 1]) {
+    scale = parseInt(args[++i], 10);
   } else if (args[i] === '--no-gamepad') {
     disableGamepad = true;
   } else if (args[i] === '--debug-input') {
@@ -86,7 +92,7 @@ if (!saveDir) {
 }
 
 // Initialize subsystems
-const videoOutput = new VideoOutput();
+const videoOutput = new VideoOutput({ video: videoMode, scale });
 await videoOutput.init();
 videoOutput.setFrameSkip(frameSkip);
 videoOutput.setContrast(contrast);
@@ -177,6 +183,8 @@ function printUsage() {
   console.log(`  --contrast <n>       Contrast boost, 1.0=normal, 1.5=more contrast (default: 1.0)`);
   console.log(``);
   console.log(`Graphics options:`);
+  console.log(`  --video <mode>       Video output: terminal, sdl, both (default: terminal)`);
+  console.log(`  --scale <n>          SDL window scale factor (default: 2)`);
   console.log(`  --symbols <type>     Symbol set: block, half, ascii, solid, stipple,`);
   console.log(`                       quad, sextant, octant, braille (default: block)`);
   console.log(`  --colors <mode>      Color mode: true, 256, 16, 2 (default: true)`);

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "gamepad-node": "^1.3.0",
     "@kmamal/sdl": "^0.11.13",
     "@monteslu/chafa-wasm": "^0.4.0",
+    "gamepad-node": "^1.3.1",
     "yauzl": "^3.2.0"
   },
   "devDependencies": {

--- a/src/video/SDLRenderer.js
+++ b/src/video/SDLRenderer.js
@@ -1,0 +1,45 @@
+import sdl from '@kmamal/sdl';
+
+export class SDLRenderer {
+  constructor(options = {}) {
+    this.window = null;
+    this.title = options.title || 'retroemu';
+    this.scale = options.scale || 2;
+  }
+
+  init(width, height) {
+    // Create window with specified dimensions
+    // We multiply by scale for visibility on high-res screens
+    this.window = sdl.video.createWindow({
+      title: this.title,
+      width: width * this.scale,
+      height: height * this.scale,
+      resizable: true,
+      fullscreen: false
+    });
+
+    this.window.on('close', () => {
+      this.destroy();
+      process.exit(0);
+    });
+  }
+
+  render(rgbaBuffer, width, height) {
+    if (!this.window) return;
+    
+    // Convert Uint8ClampedArray to Buffer if needed
+    // @kmamal/sdl expects a Buffer or TypedArray
+    // The stride/pitch is width * 4 bytes (RGBA)
+    const pitch = width * 4;
+    
+    // render(width, height, stride, format, buffer)
+    this.window.render(width, height, pitch, 'rgba32', Buffer.from(rgbaBuffer));
+  }
+
+  destroy() {
+    if (this.window) {
+      this.window.destroy();
+      this.window = null;
+    }
+  }
+}


### PR DESCRIPTION
Implements #1 by adding an optional SDL window renderer using `@kmamal/sdl`.

Usage:
`retroemu game.md --video=sdl`
`retroemu game.md --video=both`